### PR TITLE
Fixed the setup steps for CPR on linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,8 @@ def installCPR():
 		run("deps\\cpr\\opt\\curl\\buildconf.bat")
 		#run("C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\bin\\vcvars32.bat")
 	if linux:
+		os.chmod("./deps/cpr/opt/curl/buildconf", 0o777)
+		os.chdir("./deps/cpr/opt/curl")
 		run("./deps/cpr/opt/curl/buildconf")
 
 def installWebsocketPP():


### PR DESCRIPTION
Two errors were stopping the automation of the deps setup on Linux:

1. buildconf wasn't executable at the moment of running, so I added a chmod step to it. The permitions COULD be fine-tuned to rwxr-xr-x, but I don't think it matters much.
2. curl required working directory to be the same one as the buildconf, so I added a chdir step, and corrected the path to `run`.

Also there might be an issue with tabs because my vim setup hates them (and with good reason :stuck_out_tongue:)

There's probably a more elegant way of doing it, but since this works (and it should for every possible setup), I haven't bothered looking deeper into it.