### PR TITLE
Fixed Makefile

### DIFF
--- a/buildtools/Makefile.linux
+++ b/buildtools/Makefile.linux
@@ -1,17 +1,33 @@
-         CXX       = g++ #compiler
+.SUFFIXES:
+.SUFFIXES: .c .cpp .o .a
+
+         CC        = gcc # c compiler
+         CXX       = g++ # c++ compiler
          AR        = ar rv
-         DFLAGS    = -Wall -c -std=c++11 -fPIC
-override FLAGS    := $(DFLAGS) $(FLAGS)
-         SOURCE    = ../sleepy_discord
-         INCLUDE   = ../include/sleepy_discord ../deps/include ../include/sleepy_discord/IncludeNonexistent
-         TARGET    = libsleepy_discord
-         SUFFIX    = .a
-         OUTPUT    = $(TARGET)$(SUFFIX)
+         CPPFLAGS  = -I../include/sleepy_discord -I../deps/include -I../include/sleepy_discord/IncludeNonexistent -Wall -fPIC
+override CFLAGS    =
+override CXXFLAGS  = -std=c++11
+         SRCDIR    = ../sleepy_discord
+         DESTDIR   = .
+         CXXOBJS  := $(patsubst %.cpp,%.o,$(wildcard $(SRCDIR)/*.cpp))
+         COBJS    := $(patsubst %.c,%.o,$(wildcard $(SRCDIR)/*.c))
 
-all: ${TARGET}.o ar
+all: libcpr.a libsleepy_discord.a
 
-$(TARGET).o: 
-	$(CXX) $(FLAGS) $(SOURCE)/*.cpp $(foreach dir, $(INCLUDE), -I $(dir))
+clean:
+	rm -f $(DESTDIR)/*.o
+	rm -f $(DESTDIR)/*.a
 
-ar:
-	$(AR) $(OUTPUT) *.o
+c++: $(CXXOBJS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $^
+
+c: $(COBJS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $^
+
+libsleepy_discord.a: $(COBJS) $(CXXOBJS)
+	$(AR) $@ $^
+
+libcpr.a: $(patsubst %.cpp,%.o,$(wildcard ../deps/cpr/cpr/*.cpp))
+	sed -i '25,26d' ../deps/cpr/cpr/error.cpp # duplicate case value
+	$(CXX) -I../deps/include -c ../deps/cpr/cpr/*.cpp
+	$(AR) $@ $^

--- a/buildtools/Makefile.linux
+++ b/buildtools/Makefile.linux
@@ -4,30 +4,26 @@
          CC        = gcc # c compiler
          CXX       = g++ # c++ compiler
          AR        = ar rv
-         CPPFLAGS  = -I../include/sleepy_discord -I../deps/include -I../include/sleepy_discord/IncludeNonexistent -Wall -fPIC
-override CFLAGS    =
-override CXXFLAGS  = -std=c++11
+         CPPFLAGS  = -Wall -fPIC -c $(foreach dir, $(INCLUDE), -I$(dir))
+override CFLAGS   +=
+override CXXFLAGS += -std=c++11
          SRCDIR    = ../sleepy_discord
+         INCLUDE   = ../include/sleepy_discord ../deps/include ../include/sleepy_discord/IncludeNonexistent
          DESTDIR   = .
-         CXXOBJS  := $(patsubst %.cpp,%.o,$(wildcard $(SRCDIR)/*.cpp))
-         COBJS    := $(patsubst %.c,%.o,$(wildcard $(SRCDIR)/*.c))
+         COBJS     = $(patsubst %.c,%.o,$(wildcard $(SRCDIR)/*.c))
+         CXXOBJS   = $(patsubst %.cpp,%.o,$(wildcard $(SRCDIR)/*.cpp))
 
-all: libcpr.a libsleepy_discord.a
+all: libsleepy_discord.a libcpr-patch libcpr.a
 
 clean:
-	rm -f $(DESTDIR)/*.o
-	rm -f $(DESTDIR)/*.a
-
-c++: $(CXXOBJS)
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $^
-
-c: $(COBJS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $^
+	rm $(DESTDIR)/*.a
 
 libsleepy_discord.a: $(COBJS) $(CXXOBJS)
 	$(AR) $@ $^
 
 libcpr.a: $(patsubst %.cpp,%.o,$(wildcard ../deps/cpr/cpr/*.cpp))
-	sed -i '25,26d' ../deps/cpr/cpr/error.cpp # duplicate case value
-	$(CXX) -I../deps/include -c ../deps/cpr/cpr/*.cpp
 	$(AR) $@ $^
+
+libcpr-patch:
+	# duplicate case value in lines 25,26
+	sed -i 's/.*VER.*//; s/.*REM.*//' ../deps/cpr/cpr/error.cpp 

--- a/buildtools/Makefile.linux
+++ b/buildtools/Makefile.linux
@@ -12,16 +12,20 @@ override CXXFLAGS += -std=c++11
          DESTDIR   = .
          COBJS     = $(patsubst %.c,%.o,$(wildcard $(SRCDIR)/*.c))
          CXXOBJS   = $(patsubst %.cpp,%.o,$(wildcard $(SRCDIR)/*.cpp))
+         CPROBJS   = $(patsubst %.cpp,%.o,$(wildcard ../deps/cpr/cpr/*.cpp))
 
 all: libsleepy_discord.a libcpr-patch libcpr.a
 
 clean:
-	rm $(DESTDIR)/*.a
+	rm -f $(DESTDIR)/*.a
+	rm -f $(COBJS)
+	rm -f $(CXXOBJS)
+	rm -f $(CPROBJS)
 
 libsleepy_discord.a: $(COBJS) $(CXXOBJS)
 	$(AR) $@ $^
 
-libcpr.a: $(patsubst %.cpp,%.o,$(wildcard ../deps/cpr/cpr/*.cpp))
+libcpr.a: $(CPROBJS)
 	$(AR) $@ $^
 
 libcpr-patch:


### PR DESCRIPTION
Being one of the (many) people that prefer good old Make, I polished up the linux build.
It now properly links the C json library that json_wrapper depends on and compiles the cpr source into a static executable in buildtools/ (thus no change to the compilation command is necessary).

This should resolve https://github.com/yourWaifu/sleepy-discord/issues/110.

P.S. It seems that CPR is deprecated and broken (hence the patch).