### PR TITLE
Fixed a spelling mistake (hasPremission -> hasPermission)

### DIFF
--- a/include/sleepy_discord/permissions.h
+++ b/include/sleepy_discord/permissions.h
@@ -66,7 +66,7 @@ namespace SleepyDiscord {
 		return static_cast<Permission>(static_cast<int64_t>(a) ^ static_cast<int64_t>(b));
 	}
 	
-	inline constexpr bool hasPremission(const Permission& target, const Permission& permission) {
+	inline constexpr bool hasPermission(const Permission& target, const Permission& permission) {
 		return (target & permission) == permission;
 	}
 

--- a/sleepy_discord/permissions.cpp
+++ b/sleepy_discord/permissions.cpp
@@ -40,7 +40,7 @@ namespace SleepyDiscord {
 				permissions = permissions | rolePermissions->permissions;
 		}
 
-		if (hasPremission(permissions, Permission::ADMINISTRATOR))
+		if (hasPermission(permissions, Permission::ADMINISTRATOR))
 			return Permission::ALL;
 		return permissions;
 	}
@@ -54,7 +54,7 @@ namespace SleepyDiscord {
 	}
 
 	Permission overwritePermissions(const Permission basePermissions, const Server& server, const ServerMember& member, const Channel& channel) {
-		if (hasPremission(basePermissions, Permission::ADMINISTRATOR))
+		if (hasPermission(basePermissions, Permission::ADMINISTRATOR))
 			return Permission::ALL;
 
 		Permission permissions = basePermissions;


### PR DESCRIPTION
In `permissions.cpp` and `permissions.h,` there was a function named `hasPremission` which I presume was intended to be called `hasPermission`