### PR TITLE
Add support for uploading files from memory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if(AUTO_DOWNLOAD_LIBRARY)
 		#to do install libssl-dev
 		download_project(
 			PROJ           cpr
-			GIT_REPOSITORY https://github.com/whoshuu/cpr.git
+			GIT_REPOSITORY https://github.com/MacDue/cpr
 			GIT_TAG        master
 			SOURCE_DIR     ${PROJECT_SOURCE_DIR}/deps/cpr
 			UPDATE_DISCONNECTED 1
@@ -167,6 +167,7 @@ if(USE_CPR)
 			set(CMAKE_USE_OPENSSL OFF CACHE BOOL "")
 		endif()
 	endif()
+	set(CMAKE_USE_OPENSSL ON)
 	if(NOT DEFINED USE_SYSTEM_CURL AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 		#using cmake to configure curl on linux has issues
 		#so use system curl

--- a/include/sleepy_discord/client.h
+++ b/include/sleepy_discord/client.h
@@ -187,6 +187,7 @@ namespace SleepyDiscord {
 		ObjectResponse<Message     > sendMessage             (Snowflake<Channel> channelID, std::string message, Embed embed = Embed::Flag::INVALID_EMBED, bool tts = false, RequestSettings<ObjectResponse<Message>> settings = {});
 		ObjectResponse<Message     > sendMessage             (SendMessageParams params                                                                                     , RequestSettings<ObjectResponse<Message>> settings = {});
 		ObjectResponse<Message     > uploadFile              (Snowflake<Channel> channelID, std::string fileLocation, std::string message                                  , RequestSettings<ObjectResponse<Message>> settings = {});
+		ObjectResponse<Message     > uploadFile              (Snowflake<Channel> channelID, uint8_t* buffer, size_t buffer_len, std::string message, std::string filename                                 , RequestSettings<ObjectResponse<Message>> settings = {});
 		BoolResponse                 addReaction             (Snowflake<Channel> channelID, Snowflake<Message> messageID, std::string emoji                                , RequestSettings<BoolResponse           > settings = {});
 		BoolResponse                 removeReaction          (Snowflake<Channel> channelID, Snowflake<Message> messageID, std::string emoji, Snowflake<User> userID = "@me");
 		ArrayResponse <Reaction    > getReactions            (Snowflake<Channel> channelID, Snowflake<Message> messageID, std::string emoji                                , RequestSettings<ArrayResponse<Reaction>> settings = {});

--- a/include/sleepy_discord/http.h
+++ b/include/sleepy_discord/http.h
@@ -41,7 +41,7 @@ namespace SleepyDiscord {
 		Part(const std::string _name, const filePathPart _file) :
 			name(_name), value(_file.filePath), isFile(true), buffer(nullptr), buffer_len(0) {}
 		Part(const std::string _name, uint8_t* buffer, size_t len) :
-			name(_name), buffer(buffer), buffer_len(len), isFile(false) {}
+			name(_name), value{}, isFile(false), buffer(buffer), buffer_len(len) {}
 		const std::string name;
 		const std::string value;
 		const bool isFile;   //if isFile is true then value is the filepath

--- a/include/sleepy_discord/http.h
+++ b/include/sleepy_discord/http.h
@@ -37,12 +37,16 @@ namespace SleepyDiscord {
 
 	struct Part {
 		Part(const std::string _name, const std::string _value) :
-			name(_name), value(_value), isFile(false) {}
+			name(_name), value(_value), isFile(false), buffer(nullptr), buffer_len(0) {}
 		Part(const std::string _name, const filePathPart _file) :
-			name(_name), value(_file.filePath), isFile(true) {}
+			name(_name), value(_file.filePath), isFile(true), buffer(nullptr), buffer_len(0) {}
+		Part(const std::string _name, uint8_t* buffer, size_t len) :
+			name(_name), buffer(buffer), buffer_len(len), isFile(false) {}
 		const std::string name;
 		const std::string value;
 		const bool isFile;   //if isFile is true then value is the filepath
+		const uint8_t* buffer;
+		const size_t buffer_len;
 	};
 
 	typedef std::initializer_list<Part> Multipart;

--- a/include/sleepy_discord/json_wrapper.h
+++ b/include/sleepy_discord/json_wrapper.h
@@ -10,6 +10,7 @@ typedef std::size_t SizeType;
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/stringbuffer.h"
+#include "rapidjson/istreamwrapper.h"
 #include "nonstd/string_view.hpp"
 //#include "json.h"
 

--- a/include/sleepy_discord/message.h
+++ b/include/sleepy_discord/message.h
@@ -141,9 +141,9 @@ namespace SleepyDiscord {
 			assert(outOfDateMessage.ID == messageID);
 			json::fromJSON(outOfDateMessage, RevisionsJSON);
 		}
+    const json::Value& RevisionsJSON;
 		Snowflake<Message> messageID;
 		Snowflake<Channel> channelID;
-		const json::Value& RevisionsJSON;
 	};
 
 	struct SendMessageParams : public DiscordObject {

--- a/sleepy_discord/client.cpp
+++ b/sleepy_discord/client.cpp
@@ -1,3 +1,4 @@
+#define SLEEPY_USE_HARD_CODED_GATEWAY
 #if _MSC_VER && !__INTEL_COMPILER
 #pragma warning( disable: 4307 )  //ignore integer overflow, becuase we are taking advantage of it
 #endif

--- a/sleepy_discord/cpr_session.cpp
+++ b/sleepy_discord/cpr_session.cpp
@@ -12,8 +12,14 @@ namespace SleepyDiscord {
 	void CPRSession::setMultipart(const std::initializer_list<Part>& parts) {
 		std::vector<cpr::Part> cprParts;
 		for (Part m : parts) {
-			if (m.isFile) cprParts.push_back(cpr::Part(m.name, cpr::File(m.value)));
-			else          cprParts.push_back(cpr::Part(m.name, m.value));
+			if (m.isFile) 
+				cprParts.push_back(cpr::Part(m.name, cpr::File(m.value)));
+			else if (m.buffer_len > 0) {
+				auto buffer = cpr::Buffer(m.buffer, m.buffer + m.buffer_len, m.name);
+				cprParts.push_back(cpr::Part(m.name, buffer));
+			}
+			else
+				cprParts.push_back(cpr::Part(m.name, m.value));
 		}
 
 		muiltpart.parts = cprParts;

--- a/sleepy_discord/endpoints.cpp
+++ b/sleepy_discord/endpoints.cpp
@@ -60,6 +60,15 @@ namespace SleepyDiscord {
 		};
 	}
 
+	ObjectResponse<Message> BaseDiscordClient::uploadFile(Snowflake<Channel> channelID, uint8_t* buffer, size_t buffer_len,  std::string message, std::string filename, RequestSettings<ObjectResponse<Message>> settings) {
+		return ObjectResponse<Message>{
+			request(Post, path("channels/{channel.id}/messages", { channelID }), settings, "", {
+				{ "content", message },
+				{ filename, buffer, buffer_len }
+			})
+		};
+	}
+
 	ObjectResponse<Message> BaseDiscordClient::editMessage(Snowflake<Channel> channelID, Snowflake<Message> messageID, std::string newMessage, RequestSettings<ObjectResponse<Message>> settings) {
 		rapidjson::Document doc;
 		doc.SetObject();


### PR DESCRIPTION
This PR allows for uploading files directly from memory (a feature I needed).
```c++
uploadFile(Snowflake<Channel> channelID, uint8_t* buffer, size_t buffer_len, std::string message, std::string filename)
```

**Note!**
This PR changes the cpr repo to  https://github.com/MacDue/cpr ! 
This is due to a bug with cpr where uploading files larger than 16,000bytes would corrupt the file -- which I repaired in my fork. Issue described here: https://github.com/whoshuu/cpr/issues/342