### PR TITLE
Reduce compile warnings on clang-9.0

### DIFF
--- a/include/sleepy_discord/asio_schedule.h
+++ b/include/sleepy_discord/asio_schedule.h
@@ -32,7 +32,7 @@ namespace SleepyDiscord {
 			}
 		}
 
-		inline Timer schedule(TimedTask code, const time_t milliseconds) {
+		inline Timer schedule(TimedTask code, const time_t milliseconds) override {
 			auto timer = std::make_shared<asio::steady_timer>(io, asio::chrono::milliseconds(milliseconds));
 			timer->async_wait(std::bind(&handleTimer, std::placeholders::_1, code));
 			return Timer([timer]() {

--- a/include/sleepy_discord/cache.h
+++ b/include/sleepy_discord/cache.h
@@ -13,7 +13,7 @@ namespace SleepyDiscord {
 	public:
 		using Type = _Type;
 		using Parent = std::unordered_map<typename Snowflake<Type>::RawType, Type>;
-		using Parent::unordered_map;
+		using typename Parent::unordered_map;
 		using Key = typename Snowflake<Type>::RawType;
 		Cache() : Parent() {}
 		Cache(Parent map) : Parent(map) {}

--- a/include/sleepy_discord/voice_connection.h
+++ b/include/sleepy_discord/voice_connection.h
@@ -136,10 +136,10 @@ namespace SleepyDiscord {
 		//This function below is here in case the user uses this class
 		virtual void read(AudioTransmissionDetails& /*details*/, int16_t*& /*buffer*/, std::size_t& /*length*/) {};
 
-		enum SpeakingFlag : int {
-			Microphone = 1 << 0,
-			Soundshare = 1 << 1,
-			Priority = 1 << 2,
+		enum SpeakingFlag : unsigned int {
+			Microphone = 1u << 0u,
+			Soundshare = 1u << 1u,
+			Priority = 1u << 2u,
 		};
 		SpeakingFlag speakingFlag = Microphone;
 	};

--- a/include/sleepy_discord/voice_connection.h
+++ b/include/sleepy_discord/voice_connection.h
@@ -21,7 +21,7 @@ namespace SleepyDiscord {
 
 	class BaseVoiceEventHandler {
 	public:
-
+		virtual ~BaseVoiceEventHandler() = default;
 		virtual void onReady(VoiceConnection&) {}
 		virtual void onSpeaking(VoiceConnection&) {}
 		virtual void onEndSpeaking(VoiceConnection&) {}
@@ -147,15 +147,16 @@ namespace SleepyDiscord {
 	struct BaseAudioOutput {
 		using Container = std::array<AudioSample, AudioTransmissionDetails::proposedLength()>;
 		BaseAudioOutput() = default;
+		virtual ~BaseAudioOutput() = default;
 		virtual void write(Container audio, AudioTransmissionDetails& details) {}
-		private:
+	private:
 		friend VoiceConnection;
 	};
 
 	struct AudioTimer {
 		Timer timer;
 		time_t nextTime = 0;
-		void stop() {
+		void stop() const {
 			if (timer.isValid())
 				timer.stop();
 		}

--- a/include/sleepy_discord/voice_connection.h
+++ b/include/sleepy_discord/voice_connection.h
@@ -132,7 +132,7 @@ namespace SleepyDiscord {
 		BaseAudioSource(AudioSourceType typ) : type(typ) {}
 		virtual inline bool isOpusEncoded() { return false; }
 		const AudioSourceType type;
-		virtual ~BaseAudioSource() {}
+		virtual ~BaseAudioSource() = default;
 		//This function below is here in case the user uses this class
 		virtual void read(AudioTransmissionDetails& /*details*/, int16_t*& /*buffer*/, std::size_t& /*length*/) {};
 

--- a/include/sleepy_discord/voice_connection.h
+++ b/include/sleepy_discord/voice_connection.h
@@ -50,7 +50,7 @@ namespace SleepyDiscord {
 			eventHandler = std::unique_ptr<BaseVoiceEventHandler>(source);
 		}
 
-		inline const bool hasVoiceHandler() {
+		inline bool hasVoiceHandler() {
 			return eventHandler != nullptr;
 		}
 
@@ -129,15 +129,14 @@ namespace SleepyDiscord {
 
 	struct BaseAudioSource {
 		BaseAudioSource() : type(AUDIO_BASE_TYPE) {}
-		BaseAudioSource(AudioSourceType typ) : type(typ) {}
+		explicit BaseAudioSource(AudioSourceType typ) : type(typ) {}
 		virtual inline bool isOpusEncoded() { return false; }
 		const AudioSourceType type;
 		virtual ~BaseAudioSource() = default;
 		//This function below is here in case the user uses this class
 		virtual void read(AudioTransmissionDetails& /*details*/, int16_t*& /*buffer*/, std::size_t& /*length*/) {};
 
-		using SpeakingFlagRaw = int;
-		enum SpeakingFlag : SpeakingFlagRaw {
+		enum SpeakingFlag : int {
 			Microphone = 1 << 0,
 			Soundshare = 1 << 1,
 			Priority = 1 << 2,
@@ -147,7 +146,7 @@ namespace SleepyDiscord {
 
 	struct BaseAudioOutput {
 		using Container = std::array<AudioSample, AudioTransmissionDetails::proposedLength()>;
-		BaseAudioOutput() {}
+		BaseAudioOutput() = default;
 		virtual void write(Container audio, AudioTransmissionDetails& details) {}
 		private:
 		friend VoiceConnection;
@@ -173,7 +172,7 @@ namespace SleepyDiscord {
 			return this == &right;
 		}
 
-		inline const bool isReady() {
+		inline bool isReady() const {
 			return state & State::ABLE;
 		}
 
@@ -181,12 +180,12 @@ namespace SleepyDiscord {
 			audioSource = std::unique_ptr<BaseAudioSource>(source);
 		}
 
-		inline const bool hasAudioSource() {
+		inline bool hasAudioSource() const {
 			return audioSource != nullptr;
 		}
 
 		inline BaseAudioSource& getAudioSource() {
-			return *(audioSource.get());
+			return *audioSource;
 		}
 
 		/*To do there might be a way to prevent code reuse here*/
@@ -195,12 +194,12 @@ namespace SleepyDiscord {
 			audioOutput = std::unique_ptr<BaseAudioOutput>(output);
 		} 
 
-		inline const bool hasAudioOutput() {
+		inline bool hasAudioOutput() const {
 			return audioOutput != nullptr;
 		}
 
 		inline BaseAudioOutput& getAudioOutput() {
-			return *(audioOutput.get());
+			return *audioOutput;
 		}
 
 		//=== startSpeaking functions ===
@@ -334,7 +333,7 @@ namespace SleepyDiscord {
 
 	struct BasicAudioSourceForContainers : public BaseAudioSource {
 		BasicAudioSourceForContainers() : BaseAudioSource(AUDIO_CONTAINER) {}
-		void read(AudioTransmissionDetails& /*details*/, int16_t*& /*buffer*/, std::size_t& /*length*/) override {}
+		virtual void read(AudioTransmissionDetails& /*details*/, int16_t*& /*buffer*/, std::size_t& /*length*/) override {}
 		virtual void speak(
 			VoiceConnection& connection,
 			AudioTransmissionDetails& details,

--- a/include/sleepy_discord/voice_connection.h
+++ b/include/sleepy_discord/voice_connection.h
@@ -334,7 +334,6 @@ namespace SleepyDiscord {
 
 	struct BasicAudioSourceForContainers : public BaseAudioSource {
 		BasicAudioSourceForContainers() : BaseAudioSource(AUDIO_CONTAINER) {}
-		virtual void read(AudioTransmissionDetails& /*details*/, int16_t*& /*buffer*/, std::size_t& /*length*/) override {}
 		virtual void speak(
 			VoiceConnection& connection,
 			AudioTransmissionDetails& details,

--- a/include/sleepy_discord/voice_connection.h
+++ b/include/sleepy_discord/voice_connection.h
@@ -306,8 +306,7 @@ namespace SleepyDiscord {
 		uint16_t sequence = 0;
 		uint32_t timestamp = 0;
 
-		#define SECRET_KEY_SIZE 32
-		unsigned char secretKey[SECRET_KEY_SIZE];
+		std::array<unsigned char, 32> secretKey;
 		static constexpr int nonceSize = 24;
 
 		//to do use this for events
@@ -346,6 +345,7 @@ namespace SleepyDiscord {
 	public:
 		using Container = _Container;
 		AudioSource() : BasicAudioSourceForContainers() {}
+		virtual void read(AudioTransmissionDetails& /*details*/, int16_t*& /*buffer*/, std::size_t& /*length*/)  override {};
 		virtual void read(AudioTransmissionDetails& details, Container& target) {};
 	private:
 		friend VoiceConnection;

--- a/include/sleepy_discord/websocketpp_websocket.h
+++ b/include/sleepy_discord/websocketpp_websocket.h
@@ -36,8 +36,8 @@ namespace SleepyDiscord {
 
 		using TimerPointer = std::weak_ptr<websocketpp::lib::asio::steady_timer>;
 
-		void run();
-		Timer schedule(TimedTask code, const time_t milliseconds);
+		void run() override;
+		Timer schedule(TimedTask code, const time_t milliseconds) override;
 		void postTask(PostableTask code) override {
 			asio::post(code);
 		}
@@ -50,14 +50,14 @@ namespace SleepyDiscord {
 			GenericMessageReceiver* messageProcessor,
 			WebsocketConnection& connection
 		) override;
-		void disconnect(unsigned int code, const std::string reason, WebsocketConnection& connection);
+		void disconnect(unsigned int code, const std::string reason, WebsocketConnection& connection) override;
 		void onClose(
 			websocketpp::connection_hdl handle,
 			GenericMessageReceiver* messageProcessor
 		);
 		void onFail(websocketpp::connection_hdl handle, GenericMessageReceiver* messageProcessor);
-		void send(std::string message, WebsocketConnection& connection);
-		void runAsync();
+		void send(std::string message, WebsocketConnection& connection) override;
+		void runAsync() override;
 		void onOpen(websocketpp::connection_hdl hdl, GenericMessageReceiver* messageProcessor);
 		void onMessage(
 			websocketpp::connection_hdl hdl,

--- a/sleepy_discord/voice_connection.cpp
+++ b/sleepy_discord/voice_connection.cpp
@@ -165,7 +165,7 @@ namespace SleepyDiscord {
 			const json::Value& secretKeyJSON = d["secret_key"];
 			json::Array secretKeyJSONArray = secretKeyJSON.GetArray();
 			const std::size_t secretKeyJSONArraySize = secretKeyJSONArray.Size();
-			for (std::size_t i = 0; i < SECRET_KEY_SIZE && i < secretKeyJSONArraySize; ++i) {
+			for (std::size_t i = 0; i < secretKey.max_size() && i < secretKeyJSONArraySize; ++i) {
 					secretKey[i] = secretKeyJSONArray[i].GetUint() & 0xFF;
 			}
 			}
@@ -415,7 +415,7 @@ namespace SleepyDiscord {
 		std::memcpy(audioDataPacket.data(), header, sizeof header);
 
 		crypto_secretbox_easy(audioDataPacket.data() + sizeof header,
-			encodedAudioData, length, nonce, secretKey);
+			encodedAudioData, length, nonce, secretKey.data());
 
 		UDP.send(audioDataPacket.data(), audioDataPacket.size());
 		samplesSentLastTime = frameSize << 1;
@@ -465,7 +465,7 @@ namespace SleepyDiscord {
 		bool isForged = crypto_secretbox_open_easy(
 			decryptedData.data(),
 			data.data() + sizeof nonce,
-			decryptedDataSize, nonce, secretKey
+			decryptedDataSize, nonce, secretKey.data()
 		) != 0;
 		if (isForged)
 			return;

--- a/sleepy_discord/websocketpp_websocket.cpp
+++ b/sleepy_discord/websocketpp_websocket.cpp
@@ -39,7 +39,7 @@ namespace SleepyDiscord {
 		this_client.set_access_channels(websocketpp::log::alevel::disconnect);
 		this_client.set_access_channels(websocketpp::log::alevel::app);
 
-		this_client.set_tls_init_handler([this](websocketpp::connection_hdl) {
+		this_client.set_tls_init_handler([](websocketpp::connection_hdl) {
 			return websocketpp::lib::make_shared<asio::ssl::context>(asio::ssl::context::tlsv1);
 		});
 


### PR DESCRIPTION
The intention was to reduce the number of compile warnings that are emitted. There are still some left, but I am not too familiar with the different async libraries used. The remaining ones come from virtual functions with the same name, but different async library specific parameters - not too sure how to fix that yet besides using common type interfaces and std::function.

mostly virtual overloads, default c'tors, d'tors, etc., missing overrides, missing consts, const on return copied return parameters

I also took the liberty of making secretkey a compile time constant array, as this couples the max size with the type and not as a seperate constant.