### PR TITLE
Fix crash when uploading a file with SleepyDiscord::Async

### DIFF
--- a/include/sleepy_discord/client.h
+++ b/include/sleepy_discord/client.h
@@ -112,14 +112,14 @@ namespace SleepyDiscord {
 
 		using RequestCallback = std::function<void(Response)>;
 		Response request(const RequestMethod method, Route path, const std::string jsonParameters = "",
-			const std::initializer_list<Part>& multipartParameters = {},
+			const std::vector<Part>& multipartParameters = {},
 			RequestCallback callback = nullptr, RequestMode mode = Sync);
 		struct Request {
 			BaseDiscordClient& client;
 			const RequestMethod method;
 			const Route url;
 			const std::string jsonParameters;
-			const std::initializer_list<Part> multipartParameters;
+			const std::vector<Part> multipartParameters;
 			const BaseDiscordClient::RequestCallback callback;
 			const RequestMode mode;
 			inline void operator()() const {
@@ -203,7 +203,7 @@ namespace SleepyDiscord {
 
 		#define RequestModeRequestDefine template<class ParmType, class Callback> \
 		static ReturnType doRequest(BaseDiscordClient& client, const RequestMethod method, Route path, \
-			const std::string jsonParameters, const std::initializer_list<Part>& multipartParameters, Callback callback) 
+			const std::string jsonParameters, const std::initializer_list<Part>& multipartParameters, Callback callback)
 
 		template<RequestMode mode> struct RequestModeType : RawRequestModeTypeHelper<Sync, void> {};
 
@@ -345,7 +345,7 @@ namespace SleepyDiscord {
 		void setIntents(IntentsRaw newIntents) { intentsIsSet = true; intents = static_cast<Intent>(newIntents); }
 		void quit() { quit(false); }	//public function for diconnecting
 		virtual void run();
-		
+
 		//array of intents
 		template<template<class...> class Container>
 		void setIntents(Container<Intent> listOfIntents) {
@@ -362,7 +362,7 @@ namespace SleepyDiscord {
 				new Handler(std::forward<Types>(arguments)...)
 			);
 		}
-		inline GenericScheduleHandler& getScheduleHandler() { return *scheduleHandler; } 
+		inline GenericScheduleHandler& getScheduleHandler() { return *scheduleHandler; }
 
 		enum AssignmentType : bool {
 			TilDueTime = 0,
@@ -376,7 +376,7 @@ namespace SleepyDiscord {
 			return     schedule(std::bind(code, this), milliseconds, mode);
 		}
 		inline  void  unschedule(const Timer& timer) const { timer.stop(); }
-		
+
 		typedef TimedTask PostableTask;
 		virtual void postTask(PostableTask code) {
 			schedule(code, 0);
@@ -407,7 +407,7 @@ namespace SleepyDiscord {
 		inline void disconnectVoiceConnection(VoiceConnection & connection) {
 			connection.disconnect();
 		}
-		
+
 		template<class Function>
 		void disconnectVoiceConnection_if(Function function) {
 			auto i = std::find_if(voiceConnections.begin(), voiceConnections.end(), function);
@@ -706,7 +706,7 @@ namespace SleepyDiscord {
 		void eraseObjectFromCache(
 			Snowflake<Server> serverID, Container Server::* container, Type ID
 		) {
-			accessIteratorFromCache(serverID, container, ID, 
+			accessIteratorFromCache(serverID, container, ID,
 				[container](Server& server, typename Container::iterator& found) {
 					(server.*(container)).erase(found);
 				}
@@ -721,7 +721,7 @@ namespace SleepyDiscord {
 	//	return static_cast<BaseDiscordClient::AssignmentType>(static_cast<char>(left) & static_cast<char>(right));
 	//}
 
-	/*Used when you like to have the DiscordClient to handle the timer via a loop but 
+	/*Used when you like to have the DiscordClient to handle the timer via a loop but
 	  don't want to do yourself. I plan on somehow merging this with the baseClient
 	  somehow
 

--- a/include/sleepy_discord/cpr_session.h
+++ b/include/sleepy_discord/cpr_session.h
@@ -13,7 +13,7 @@ namespace SleepyDiscord {
 			session.SetBody(cpr::Body{ *jsonParameters });
 		}
 		void setHeader(const std::vector<HeaderPair>& header);
-		void setMultipart(const std::initializer_list<Part>& parts);
+		void setMultipart(const std::vector<Part>& parts);
 		void setResponseCallback(const ResponseCallback& callback) {
 			responseCallback = callback;
 		}

--- a/include/sleepy_discord/custom_session.h
+++ b/include/sleepy_discord/custom_session.h
@@ -15,7 +15,7 @@ namespace SleepyDiscord {
 		inline void setHeader(const std::vector<HeaderPair>& header) {
 			session->setHeader(header);
 		}
-		inline void setMultipart(const std::initializer_list<Part>& parts) {
+		inline void setMultipart(const std::vector<Part>& parts) {
 			session->setMultipart(parts);
 		}
 		inline void setResponseCallback(const ResponseCallback& callback) {

--- a/include/sleepy_discord/http.h
+++ b/include/sleepy_discord/http.h
@@ -60,12 +60,12 @@ namespace SleepyDiscord {
 		virtual void setUrl(const std::string& url) = 0;
 		virtual void setBody(const std::string* jsonParameters) = 0;
 		virtual void setHeader(const std::vector<HeaderPair>& header) = 0;
-		virtual void setMultipart(const std::initializer_list<Part>& parts) = 0;
+		virtual void setMultipart(const std::vector<Part>& parts) = 0;
 		virtual void setResponseCallback(const ResponseCallback& callback) = 0;
 		virtual Response request(RequestMethod method) = 0;
 	protected:
 		//Use this to convert RequestMethod into a string
 		const char* getMethodName(const RequestMethod& method);
-		
+
 	};
 };

--- a/sleepy_discord/client.cpp
+++ b/sleepy_discord/client.cpp
@@ -63,7 +63,7 @@ namespace SleepyDiscord {
 	}
 
 	Response BaseDiscordClient::request(const RequestMethod method, Route path, const std::string jsonParameters,
-		const std::initializer_list<Part>& multipartParameters, RequestCallback callback, RequestMode mode
+		const std::vector<Part>& multipartParameters, RequestCallback callback, RequestMode mode
 	) {
 		//check if rate limited
 		Response response;

--- a/sleepy_discord/cpr_session.cpp
+++ b/sleepy_discord/cpr_session.cpp
@@ -9,7 +9,7 @@ namespace SleepyDiscord {
 		session.SetHeader(head);
 	}
 
-	void CPRSession::setMultipart(const std::initializer_list<Part>& parts) {
+	void CPRSession::setMultipart(const std::vector<Part>& parts) {
 		std::vector<cpr::Part> cprParts;
 		for (Part m : parts) {
 			if (m.isFile) cprParts.push_back(cpr::Part(m.name, cpr::File(m.value)));


### PR DESCRIPTION
This PR fixes using ``uploadFile`` with async requests (``SleepyDiscord::Async``).

Before the ``Request`` struct stored a copy of ``multipartParameters`` as ``std::initializer_list`` which does not copy the underlying array. So when ``uploadFile`` returned the parts were destroyed, and  ``multipartParameters`` contained dangling references & crashed during the request.

I've changed ``multipartParameters`` in the request struct to be a ``std::vector<Part>`` & changed the relevant functions.
