### PR TITLE
Fix request response being copied before it is populated

### DIFF
--- a/sleepy_discord/client.cpp
+++ b/sleepy_discord/client.cpp
@@ -72,7 +72,7 @@ namespace SleepyDiscord {
 		Route::Bucket bucket = path.bucket(method);
 
 		bool shouldCallCallback = true;
-		const auto handleCallbackCall = [=]() {
+		const auto handleCallbackCall = [&]() {
 			if (shouldCallCallback && callback)
 				callback(response);
 		};


### PR DESCRIPTION
Before, the response object was being copied when the lambda was created. That resulted in the callback being called with a copy of the response that does not have the response information.

The fix is to make it by reference instead of copy. Since the lifetime of this object is the same as the function, that will always be valid.