### PR TITLE
Updated client.h and added #include <mutex> as it was missing

### DIFF
--- a/include/sleepy_discord/client.h
+++ b/include/sleepy_discord/client.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <functional>
 #include <forward_list>
+#include <mutex>
 
 //objects
 #include "message.h"


### PR DESCRIPTION
On line 86 of the file which I have added #include <mutex> std::mutex is being used, without including mutex it causes a compiler error, because namespace std has no member mutex.