### PR TITLE
New Discord Certified Moderator Flag Add

### DIFF
--- a/include/sleepy_discord/user.h
+++ b/include/sleepy_discord/user.h
@@ -42,6 +42,7 @@ namespace SleepyDiscord {
 			Bug_Hunter_Level_2     = 1 << 14,
 			Verified_Bot           = 1 << 16,
 			Verified_Bot_Developer = 1 << 17,
+			Discord_Certified_Moderator = 1 << 18,
 		};
 
 		enum class PremiumType : int {


### PR DESCRIPTION
This pull request adds the Discord Certified Moderator badge flag to the User Flags
PR in discord-api-docs: https://github.com/discord/discord-api-docs/pull/2946