### PR TITLE
Made change for C++17

### DIFF
--- a/sleepy_discord/json_wrapper.cpp
+++ b/sleepy_discord/json_wrapper.cpp
@@ -1,5 +1,6 @@
 #include "json_wrapper.h"
 #include <stdexcept>
+#include <string>
 
 namespace SleepyDiscord { namespace json {
 	const std::string createJSON(std::initializer_list<std::pair<std::string, std::string>> json) {


### PR DESCRIPTION
When compiling for C++17, was getting an error about the to_string method not existing in json_wrapper.cpp. Detailed in issue #221. Fixed it by adding the necessary import statement to the file.