### PR TITLE
fix 1 of the many compilation errors with gcc-11

### DIFF
--- a/include/sleepy_discord/json_wrapper.h
+++ b/include/sleepy_discord/json_wrapper.h
@@ -88,7 +88,7 @@ namespace SleepyDiscord {
 		template<class TypeToConvertTo, class Base = ArrayStringWrapper>
 		struct ArrayWrapper : public Base {
 			using Base::Base;
-			using DocType = decltype(((Base*)nullptr)->getDoc());
+			using DocType = decltype(std::declval<Base>().getDoc());
 			template<class Container>
 			Container get(DocType doc) {
 				Array jsonArray = doc.template Get<Array>();


### PR DESCRIPTION
std::declval is c++11 so this shouldn't have any side effects