### PR TITLE
[Bug fix] member & channel merges on server update

### DIFF
--- a/sleepy_discord/client.cpp
+++ b/sleepy_discord/client.cpp
@@ -485,7 +485,7 @@ namespace SleepyDiscord {
 			case hash("GUILD_UPDATE"               ): {
 				Server server(d);
 				accessServerFromCache(server.ID, [server](Server& foundServer) {
-					foundServer = server;
+					json::mergeObj(foundServer, server);
 				});
 				onEditServer(server);
 				} break;


### PR DESCRIPTION
server object that gets passed by discord doesn't pass the member or channels, we need to do a merge rather than just pushing the new server object onto the old server object.