### PR TITLE
Fixed small warnings on C++20

### DIFF
--- a/include/sleepy_discord/client.h
+++ b/include/sleepy_discord/client.h
@@ -702,7 +702,7 @@ namespace SleepyDiscord {
 		void findServerInCache(Snowflake<Server>& serverID, Callback onSuccessCallback) {
 			if (serverCache) {
 				ServerCache::iterator server = serverCache->findServer(serverID);
-				if (server != serverCache->end()) {
+				if (server != static_cast<ServerCache::const_iterator>(serverCache->end())) {
 					onSuccessCallback(server);
 				}
 			}

--- a/include/sleepy_discord/client.h
+++ b/include/sleepy_discord/client.h
@@ -702,7 +702,7 @@ namespace SleepyDiscord {
 		void findServerInCache(Snowflake<Server>& serverID, Callback onSuccessCallback) {
 			if (serverCache) {
 				ServerCache::iterator server = serverCache->findServer(serverID);
-				if (server != static_cast<ServerCache::const_iterator>(serverCache->end())) {
+				if (server != static_cast<const ServerCache::iterator>(serverCache->end())) {
 					onSuccessCallback(server);
 				}
 			}

--- a/include/sleepy_discord/rapidjson/document.h
+++ b/include/sleepy_discord/rapidjson/document.h
@@ -807,7 +807,7 @@ public:
                 break;
 
             case kObjectFlag:
-                for (MemberIterator m = MemberBegin(); m != MemberEnd(); ++m)
+                for (MemberIterator m = MemberBegin(); m != static_cast<ConstMemberIterator>(MemberEnd()); ++m)
                     m->~Member();
                 Allocator::Free(GetMembersPointer());
                 break;
@@ -1129,7 +1129,7 @@ public:
     template <typename SourceAllocator>
     GenericValue& operator[](const GenericValue<Encoding, SourceAllocator>& name) {
         MemberIterator member = FindMember(name);
-        if (member != MemberEnd())
+        if (member != static_cast<ConstMemberIterator>(MemberEnd()))
             return member->value;
         else {
             RAPIDJSON_ASSERT(false);    // see above note
@@ -1251,7 +1251,7 @@ public:
         RAPIDJSON_ASSERT(IsObject());
         RAPIDJSON_ASSERT(name.IsString());
         MemberIterator member = MemberBegin();
-        for ( ; member != MemberEnd(); ++member)
+        for ( ; member != static_cast<ConstMemberIterator>(MemberEnd()); ++member)
             if (name.StringEqual(member->name))
                 break;
         return member;

--- a/sleepy_discord/client.cpp
+++ b/sleepy_discord/client.cpp
@@ -175,10 +175,10 @@ namespace SleepyDiscord {
 
 					auto errorCode = document.FindMember("code");
 					auto errorMessage = document.FindMember("message");
-					if (errorCode != document.MemberEnd())
+					if (errorCode != static_cast<rapidjson::GenericValue<rapidjson::UTF8<>>::ConstMemberIterator>(document.MemberEnd()))
 						onError(
 							static_cast<ErrorCode>(errorCode->value.GetInt()),
-							{ errorMessage != document.MemberEnd() ? errorMessage->value.GetString() : "" }
+							{ errorMessage != static_cast<rapidjson::GenericValue<rapidjson::UTF8<>>::ConstMemberIterator>(document.MemberEnd()) ? errorMessage->value.GetString() : "" }
 						);
 					else if (!response.text.empty())
 						onError(ERROR_NOTE, response.text);


### PR DESCRIPTION
Compiling with C++20 creates small warnings and which is about ambigous function calls,
can be fixed with 'static_cast'ing to const type of iterator.