### PR TITLE
Added activity type marker to switch between them during status update of the bot

### DIFF
--- a/include/sleepy_discord/client.h
+++ b/include/sleepy_discord/client.h
@@ -90,6 +90,15 @@ namespace SleepyDiscord {
 		DIRECT_MESSAGE_TYPING    = 1 << 14,
 	};
 
+	enum ActivityType : int8_t {
+		GAME = 0,
+		STREAMING = 1,
+		LISTENING = 2,
+		WATCHING = 3,
+		//CUSTOM = 4,  //not supported for bots
+		COMPETING =5
+	};
+
 	class BaseDiscordClient : public GenericMessageReceiver {
 	public:
 		BaseDiscordClient() = default;
@@ -413,7 +422,7 @@ namespace SleepyDiscord {
 		BoolResponse deleteStageInstance(Snowflake<Channel> channelID, RequestSettings<BoolResponse> settings = {});
 
 		//websocket functions
-		void updateStatus(std::string gameName = "", uint64_t idleSince = 0, Status status = online, bool afk = false);
+		void updateStatus(std::string gameName = "", uint64_t idleSince = 0, Status status = online, bool afk = false, ActivityType type = ActivityType::GAME);
 		void requestServerMembers(ServerMembersRequest request);
 
 		//CDN stuff

--- a/sleepy_discord/client.cpp
+++ b/sleepy_discord/client.cpp
@@ -222,7 +222,7 @@ namespace SleepyDiscord {
 		}
 	}
 
-	void BaseDiscordClient::updateStatus(std::string gameName, uint64_t idleSince, Status status, bool afk) {
+	void BaseDiscordClient::updateStatus(std::string gameName, uint64_t idleSince, Status status, bool afk, ActivityType type) {
 		std::string statusString[] = {
 			"", "online", "dnd", "idle", "invisible", "offline"
 		};
@@ -233,7 +233,7 @@ namespace SleepyDiscord {
 				{"since", idleSince != 0 ? json::UInteger(idleSince) : "null"},
 				{"game", gameName != "" ? json::createJSON({
 					{"name", json::string(gameName)},
-					{"type", json::integer(0)}
+					{"type", json::integer(type)}
 				}) : "null"},
 				{ "status", SleepyDiscord::json::string(statusString[status]) },
 				{ "afk", SleepyDiscord::json::boolean(afk) }


### PR DESCRIPTION
Small fix fully compatible with current bots but allowing to switch activity types in the simplest way

Reason: In some languages different activity types takes less space so it's possible to insert more custom data in the activity type